### PR TITLE
Allow for optional external viewer args

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 View RSS feeds from the terminal.
 
-![image](https://user-images.githubusercontent.com/4519234/77839285-49077c00-7149-11ea-80ad-76efda38615e.png)
+![image](https://user-images.githubusercontent.com/4519234/78465683-bc1f6e00-76c6-11ea-96e7-1cdd4a5c294f.png)
 
 ## configure
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -4,8 +4,9 @@ feeds:
 - https://www.reddit.com/r/golang/.rss
 - https://www.reddit.com/r/linux/.rss
 - https://www.zdnet.com/topic/security/rss.xml
-- https://aws.amazon.com/blogs/security/feed/
-- https://www.archlinux.org/feeds/news/
 
-# Optionally define an an external application viewer
+# Optionally define an application to view the feeds
 #externalViewer: firefox
+# Optionally define args for the external viewer
+#externalViewerArgs:
+    #- --new-window

--- a/config/config.go
+++ b/config/config.go
@@ -13,8 +13,9 @@ import (
 
 // Configuration stores the global config
 type Configuration struct {
-	Feeds          []string `yaml:"feeds"`
-	ExternalViewer string   `yaml:"externalViewer,omitempty"`
+	Feeds              []string `yaml:"feeds"`
+	ExternalViewer     string   `yaml:"externalViewer,omitempty"`
+	ExternalViewerArgs []string `yaml:"externalViewerArgs,omitempty"`
 }
 
 // DefaultConfiguration can be used if a config is missing
@@ -22,6 +23,7 @@ var DefaultConfiguration = Configuration{
 	Feeds: []string{
 		"https://news.ycombinator.com/rss",
 		"https://www.reddit.com/r/golang/.rss",
+		"https://www.reddit.com/r/linux/.rss",
 		"https://www.zdnet.com/topic/security/rss.xml",
 	},
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,8 +15,6 @@ func TestLoadConfiguration(t *testing.T) {
 		"https://www.reddit.com/r/golang/.rss",
 		"https://www.reddit.com/r/linux/.rss",
 		"https://www.zdnet.com/topic/security/rss.xml",
-		"https://aws.amazon.com/blogs/security/feed/",
-		"https://www.archlinux.org/feeds/news/",
 	}
 
 	assert.Equal(

--- a/cui/colours.go
+++ b/cui/colours.go
@@ -1,0 +1,8 @@
+package cui
+
+import "github.com/jroimartin/gocui"
+
+const (
+	selectionBgColor = gocui.ColorWhite
+	selectionFgColor = gocui.ColorBlack
+)

--- a/cui/main.go
+++ b/cui/main.go
@@ -63,8 +63,9 @@ func openFeed(g *gocui.Gui, v *gocui.View) error {
 func openItem(g *gocui.Gui, v *gocui.View) error {
 	_, cy := v.Cursor()
 	item := Controller.Rss.Feeds[currentFeed].Items[cy]
-	viewer := Controller.Config.ExternalViewer
-	err := exec.Command(viewer, item.Link).Start()
+	err := exec.Command(
+		Controller.Config.ExternalViewer,
+		append(Controller.Config.ExternalViewerArgs, item.Link)...).Start()
 
 	if err != nil {
 		log.Fatal(err)
@@ -138,8 +139,8 @@ func layout(g *gocui.Gui) error {
 		}
 		v.Title = "Feeds"
 		v.Highlight = true
-		v.SelBgColor = gocui.ColorGreen
-		v.SelFgColor = gocui.ColorBlack
+		v.SelBgColor = selectionBgColor
+		v.SelFgColor = selectionFgColor
 
 		if _, err = setCurrentViewOnTop(g, "feeds"); err != nil {
 			return err
@@ -154,8 +155,8 @@ func layout(g *gocui.Gui) error {
 		}
 		v.Title = "Items"
 		v.Highlight = true
-		v.SelBgColor = gocui.ColorGreen
-		v.SelFgColor = gocui.ColorBlack
+		v.SelBgColor = selectionBgColor
+		v.SelFgColor = selectionFgColor
 	}
 	return nil
 }


### PR DESCRIPTION
In order to pass in options like `--new-window` to an external viewer like
`firefox`, optional args can now be defined in configuration. See
config-example.yaml for an example.